### PR TITLE
fix: disable ESO push (GitHub App not on bitovians org)

### DIFF
--- a/deploy/values.yaml
+++ b/deploy/values.yaml
@@ -12,6 +12,14 @@ kind: static-site
 # Everything else adopts via convention names. The deploy workflow is
 # unaffected (it reads repo variables, and bucket/distribution identities
 # do not change at adoption).
+# ESO off for this site (KNOWN ISSUE): the platform GitHub App is installed
+# on the bitovi org only; pto lives in bitovians, so the Actions-secrets
+# push can never succeed (the deploy workflow reads manually-set repo
+# variables instead, and always has). Without this, the composed PushSecret
+# fails forever and holds the app Progressing.
+eso:
+  enabled: false
+
 crossplane:
   enabled: true
   deletionProtection: true


### PR DESCRIPTION
Known issue made load-bearing by the Crossplane cutover: the platform GitHub App is installed on **bitovi** only, so the Actions-secrets push targets an unreachable repo (`bitovi/pto` — wrong org in the store path, and no installation either way). The kro-era PushSecret failed silently forever; the Crossplane XR honestly refuses to report Ready over it, holding the app Progressing.

`eso.enabled: false` drops the composed CI pair + ClusterSecretStore — matching how pto actually deploys (manually-set repo `vars.*`, unchanged since before ESO existed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)